### PR TITLE
Babel6 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # babelify-jest
 
 [Babel](https://github.com/babel/babel) [jest](https://github.com/facebook/jest) plugin which handles babelify modules
-gently.
+gently. Note: As of babelify-jest 1.0.0, Babel6 is required.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -36,10 +36,9 @@ module.exports = {
 
         // Ignore all files within node_modules except babelify modules
         // babel files can be .js, .es, .jsx or .es6
-        if ((filename.indexOf("node_modules") === -1 || isBabelifyModule(filename)) && babel.canCompile(filename)) {
+        if ((filename.indexOf("node_modules") === -1 || isBabelifyModule(filename)) && babel.util.canCompile(filename)) {
             return babel.transform(src, {
                 filename: filename,
-                stage: stage,
                 retainLines: true,
                 auxiliaryCommentBefore: "istanbul ignore next"
             }).code;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "babelify-jest",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "repository": "pnuzhdin/babelify-jest",
   "dependencies": {
-    "babel-core": "^6.5.0"
+    "babel-core": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "repository": "pnuzhdin/babelify-jest",
   "dependencies": {
-    "babel-core": "^5.8.0"
+    "babel-core": "^6.5.0"
   }
 }


### PR DESCRIPTION
In addition I've bumped the major version as this is likely a compatibility break for anyone currently using Babel5 with `babelify-jest`.